### PR TITLE
spec: Migrate to Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,9 @@
 {
-    "main": "./zookeeper.js"
+  "name": "@quilt/zookeeper",
+  "version": "0.0.1",
+  "main": "./zookeeper.js",
+  "license": "MIT",
+  "dependencies": {
+    "@quilt/quilt": "quilt/quilt"
+  }
 }

--- a/zookeeper-example.js
+++ b/zookeeper-example.js
@@ -1,4 +1,5 @@
-var zookeeper = require("github.com/quilt/zookeeper");
+const {createDeployment, Machine, githubKeys} = require("@quilt/quilt");
+var zookeeper = require("./zookeeper.js");
 
 var n = 3;
 var zoo = new zookeeper.Zookeeper(n);

--- a/zookeeper.js
+++ b/zookeeper.js
@@ -1,3 +1,5 @@
+const {Service, Container, PortRange} = require("@quilt/quilt");
+
 var image = "jplock/zookeeper:3.4.8";
 var dataDir = "/tmp/zookeeper";
 


### PR DESCRIPTION
`quilt run` now runs within the Node.js runtime. This is a breaking
change, requiring a number of changes to our specs.